### PR TITLE
Add full year schedule generation

### DIFF
--- a/algo1/api/generate.py
+++ b/algo1/api/generate.py
@@ -42,13 +42,12 @@ def generateSchedule(input: ScheduleConstraints):
 
   profs = parseProfs(input.professors) #professor names
   profMatcher = matchProfName(input.professors) #professor name to Professor object
-
   prefs = parseProfPrefs(input.professors) #dictionary of prof preferences
-  avails = parseProfAvailability(input.professors, term) # Array of max courses to schedule
 
   semester_list = {"FALL": {}, "SPRING": {}, "SUMMER": {}}
 
-  for term, semester in terms.items(): 
+  for term, semester in terms.items():
+    avails = parseProfAvailability(input.professors, term) # Array of max courses to schedule 
     courses = parseCourses(semester) #course IDs
     courseMatcher = matchCourseID(semester) #courseID to Course object 
     matrix = profPrefMatrix(profs, prefs, courses) #Professor preference matrix for courses

--- a/algo1/api/generate.py
+++ b/algo1/api/generate.py
@@ -7,8 +7,8 @@ import time
 import multiprocessing as mp
 
 from .times import Times
-from .models import Professor, Course, ScheduleConstraints
-from .output import matrixToSchedule, tensorToSchedule
+from .models import Professor, Course, ScheduleConstraints, Schedule
+from .output import Schedule, tensorToSemester
 from ..randopt.rand_opt import RandOpt
 
 #Max capacity for splitting sections
@@ -23,48 +23,63 @@ def generateSchedule(input: ScheduleConstraints):
   Creates Teacher/Preference Matrix and Professor Availabilities
   Currently only handles one term at a time -- Assumes only one term to schedule will be filled
   """
+  terms = {"FALL": {}, "SPRING": {}, "SUMMER": {}}
 
   if len(input.coursesToSchedule.fallCourses) != 0:
     term = 'FALL'
-    courseInput = input.coursesToSchedule.fallCourses
+    fall_course_input = input.coursesToSchedule.fallCourses
+    terms[term] = fall_course_input
 
-  elif len(input.coursesToSchedule.springCourses) != 0:
+  if len(input.coursesToSchedule.springCourses) != 0:
     term = 'SPRING'
-    courseInput = input.coursesToSchedule.springCourses
+    spring_course_input = input.coursesToSchedule.springCourses
+    terms[term] = spring_course_input
 
-  elif len(input.coursesToSchedule.summerCourses) != 0:
+  if len(input.coursesToSchedule.summerCourses) != 0:
     term = 'SUMMER'
-    courseInput = input.coursesToSchedule.summerCourses
+    summer_course_input = input.coursesToSchedule.summerCourses
+    terms[term] = summer_course_input
 
-  courses = parseCourses(courseInput) #course IDs
-  courseMatcher = matchCourseID(courseInput) #courseID to Course object 
-  
   profs = parseProfs(input.professors) #professor names
   profMatcher = matchProfName(input.professors) #professor name to Professor object
 
   prefs = parseProfPrefs(input.professors) #dictionary of prof preferences
   avails = parseProfAvailability(input.professors, term) # Array of max courses to schedule
-  matrix = profPrefMatrix(profs, prefs, courses) #Professor preference matrix for courses
 
-  testPrint(profs, prefs, courses, avails, matrix)
+  semester_list = {"FALL": {}, "SPRING": {}, "SUMMER": {}}
 
-  #Run algorithm on teacher preference matrix
-  try:
-    output = run_random_search(courses, Times, avails, matrix)
+  for term, semester in terms.items(): 
+    courses = parseCourses(semester) #course IDs
+    courseMatcher = matchCourseID(semester) #courseID to Course object 
+    matrix = profPrefMatrix(profs, prefs, courses) #Professor preference matrix for courses
 
-  except Exception as e:
-    logger.error(f"Failed generating Schedule: {e}")
-    return None
+    testPrint(profs, prefs, courses, avails, matrix)
 
-  #Convert algorithm output to Schedule object
-  try:
-    schedule = tensorToSchedule(output, profs, courses, courseMatcher, profMatcher, term)
-    #schedule = matrixToSchedule(output, profs, courses, courseMatcher, profMatcher, term)
-  except Exception as e:
-    logger.error(f"Failed parsing generated schedule: {e}")
-    return None
+    #Run algorithm on teacher preference matrix
+    try:
+      output = run_random_search(courses, Times, avails, matrix)
 
-  return schedule
+    except Exception as e:
+      logger.error(f"Failed generating Schedule: {e}")
+      return None
+    
+    try:
+      semester = tensorToSemester(output, profs, courses, courseMatcher, profMatcher, term)
+      semester_list[term] = semester
+
+    except Exception as e:
+      logger.error(f"Failed parsing generated schedule: {e}")
+      return None
+
+  fall = semester_list["FALL"]
+  spring = semester_list["SPRING"]
+  summer = semester_list["SUMMER"]
+
+  return Schedule(
+    fallCourses=fall,
+    springCourses=spring,
+    summerCourses=summer,
+  )
 
 def run_random_search(courses, times, avails, preferences):
     card_c, card_ti, card_te = len(courses), len(times.items()), len(avails)

--- a/algo1/api/output.py
+++ b/algo1/api/output.py
@@ -10,7 +10,7 @@ from .times import Times
 logger = logging.getLogger(__name__)
 
 
-def tensorToSchedule(tensor, profs, courses, courseMatcher, profMatcher, term):
+def tensorToSemester(tensor, profs, courses, courseMatcher, profMatcher, term):
   # tensor = {(course_i, time_j, teacher_k) : pref}
 
   scheduled_courses = []
@@ -24,29 +24,15 @@ def tensorToSchedule(tensor, profs, courses, courseMatcher, profMatcher, term):
     courseID = courses[course_idx]
     course = courseMatcher[courseID] 
 
-    time = Times[time_idx] #TODO: Actual Assignments for courses
+    time = Times[time_idx] 
 
     course_obj = createCourse(course, prof, time) 
     scheduled_courses.append(course_obj)
     logger.debug(f"Prof {course_obj.prof.displayName} is teaching {course_obj.subject} {course_obj.courseNumber} {course_obj.sequenceNumber}")
 
-  #Return schedule for given term, other terms are empty
-  fall = []
-  summer = []
-  spring = []
+  return scheduled_courses
 
-  if term == 'FALL':
-    fall = scheduled_courses
-  elif term == "SPRING":
-    spring = scheduled_courses
-  elif term == "SUMMER":
-    summer = scheduled_courses
-
-  return Schedule(
-    fallCourses=fall,
-    springCourses=spring,
-    summerCourses=summer
-  )
+  
     
 
 def matrixToSchedule(matrix, profs, courses, courseMatcher, profMatcher, term): 


### PR DESCRIPTION
Enable creation of an entire year's schedule in a single request.

I've been testing with a sample JSON file with data for all three semesters that generated a schedule for fall, spring, and summer. If a semester has no data, no courses will be scheduled for that semester.

